### PR TITLE
Change the HTML outcome type to Text

### DIFF
--- a/alembic/versions/677c2930c1d7_rename_outcometype_html_to_text.py
+++ b/alembic/versions/677c2930c1d7_rename_outcometype_html_to_text.py
@@ -1,0 +1,36 @@
+"""
+Rename OutcomeType HTML to Text.
+
+Revision ID: 677c2930c1d7
+Revises: e3280edb70e5
+Create Date: 2025-11-27 10:06:33.265232
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "677c2930c1d7"
+down_revision: Union[str, Sequence[str], None] = "e3280edb70e5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    """Update the OutcomeType name."""
+    op.execute("""
+        UPDATE "OutcomeType"
+        SET "Name" = 'Text'
+        WHERE "Name" = 'HTML';
+    """)
+
+
+def downgrade():
+    """Reverse the change in case of downgrade."""
+    op.execute("""
+        UPDATE "OutcomeType"
+        SET "Name" = 'HTML'
+        WHERE "Name" = 'Text';
+    """)

--- a/autodoc/data/repositories.py
+++ b/autodoc/data/repositories.py
@@ -199,7 +199,7 @@ class OutcomeTypeRepository(Repository):
     def seed(self):
         """Ensure type tables include up to date types."""
         outcome_types_required = [
-            OutcomeType(Name="HTML", IsFile=1),
+            OutcomeType(Name="Text", IsFile=1),
             OutcomeType(Name="Microsoft Word", IsFile=1),
             OutcomeType(Name="PDF", IsFile=1),
         ]

--- a/autodoc/outcome/__init__.py
+++ b/autodoc/outcome/__init__.py
@@ -1,19 +1,12 @@
 """Expose the various Outcomes."""
 
-from .html_outcome import HTMLOutcomeService
-from .outcome import OutcomeService
+from .text_outcome import TextOutcomeService
+from .outcome import OutcomeService as OutcomeService
 from .pdf_outcome import PDFOutcomeService
 from .word_outcome import WordOutcomeService
 
 outcome_service_map = {
-    "HTML": HTMLOutcomeService,
+    "Text": TextOutcomeService,
     "Microsoft Word": WordOutcomeService,
     "PDF": PDFOutcomeService,
 }
-
-__all__ = [
-    "HTMLOutcomeService",
-    "WordOutcomeService",
-    "PDFOutcomeService",
-    "OutcomeService",
-]

--- a/autodoc/outcome/text_outcome.py
+++ b/autodoc/outcome/text_outcome.py
@@ -1,4 +1,4 @@
-"""Outcome for creating HTML Files."""
+"""Outcome for creating Text Files."""
 
 from pathlib import Path
 from typing import Optional
@@ -12,8 +12,8 @@ from autodoc.outcome.outcome import OutcomeService
 from autodoc.storage_service import LinuxStorageService
 
 
-class HTMLOutcomeService(OutcomeService):
-    """HTML Document Outcome Service."""
+class TextOutcomeService(OutcomeService):
+    """Text Document Outcome Service."""
 
     is_combination = False
 
@@ -31,7 +31,7 @@ class HTMLOutcomeService(OutcomeService):
         self.outcome = outcome
         self.rendered_text: str
 
-        logger.info(f"Creating HTMLOutcomeService class with {template_uploaded_filename=}")
+        logger.info(f"Creating LinuxStorageService class with {template_uploaded_filename=}")
 
         if template_uploaded_filename:
             self.input_storage_service = LinuxStorageService(
@@ -54,12 +54,12 @@ class HTMLOutcomeService(OutcomeService):
         self.template = Template(self.input_storage_service.get_text())
 
     def render(self, data: dict) -> None:
-        """Render the HTML document using jinja2."""
+        """Render the Text document using jinja2."""
         self.rendered_text = self.template.render(**data)
         if self.output_storage_service:
             self.output_storage_service.render(data=data)
 
     def save(self) -> None:
-        """Save the HTML document using standard write."""
+        """Save the Text document using standard write."""
         if self.output_storage_service:
             self.output_storage_service.save_text(self.rendered_text)

--- a/dashboard/blueprints/card/controllers.py
+++ b/dashboard/blueprints/card/controllers.py
@@ -124,8 +124,8 @@ def outcome_card(outcome_id: int):
     manager = get_db_manager()
     outcome = manager.outcomes.get(outcome_id=outcome_id)
 
-    if outcome.outcome_type.Name == "HTML":
-        return render_template("components/cards/outcomes/html_card.html", outcome=outcome)
+    if outcome.outcome_type.Name == "Text":
+        return render_template("components/cards/outcomes/text_card.html", outcome=outcome)
 
     if outcome.outcome_type.Name == "Microsoft Word":
         return render_template("components/cards/outcomes/word_card.html", outcome=outcome)

--- a/dashboard/blueprints/top/controllers/__init__.py
+++ b/dashboard/blueprints/top/controllers/__init__.py
@@ -7,7 +7,7 @@ from .views.csv import bp as csv_bp
 from .views.diagram import bp as diagram_bp
 from .views.excel import bp as excel_bp
 from .views.form_field import bp as form_bp
-from .views.html import bp as html_bp
+from .views.text import bp as text_bp
 from .views.outcome import bp as outcome_bp
 from .views.pdf import bp as pdf_bp
 from .views.snippet import bp as snippet_bp
@@ -25,7 +25,7 @@ top_blueprint.register_blueprint(sql_bp)
 top_blueprint.register_blueprint(form_bp)
 top_blueprint.register_blueprint(csv_bp)
 top_blueprint.register_blueprint(snippet_bp)
-top_blueprint.register_blueprint(html_bp)
+top_blueprint.register_blueprint(text_bp)
 top_blueprint.register_blueprint(word_bp)
 top_blueprint.register_blueprint(pdf_bp)
 top_blueprint.register_blueprint(source_bp)

--- a/dashboard/blueprints/top/controllers/views/text.py
+++ b/dashboard/blueprints/top/controllers/views/text.py
@@ -1,4 +1,4 @@
-"""Define HTML views."""
+"""Define Text views."""
 
 from typing import Union
 
@@ -7,16 +7,16 @@ from werkzeug.wrappers.response import Response
 
 from dashboard.database import get_db_manager
 
-from ...forms import CreateHTMLOutcomeForm
+from ...forms import CreateTextOutcomeForm
 from ...models import get_optional_new_file_template_id
 
-bp = Blueprint("html", __name__)
+bp = Blueprint("text", __name__)
 
 
-@bp.route("/workflow/<workflow_id>/add_html_outcome", methods=["GET", "POST"])
-def add_html_outcome_view(workflow_id: int) -> Union[str, Response]:
-    """Add a HTML outcome document."""
-    form = CreateHTMLOutcomeForm()
+@bp.route("/workflow/<workflow_id>/add_text_outcome", methods=["GET", "POST"])
+def add_text_outcome_view(workflow_id: int) -> Union[str, Response]:
+    """Add a Text File outcome document."""
+    form = CreateTextOutcomeForm()
     manager = get_db_manager()
 
     if form.validate_on_submit():
@@ -40,7 +40,7 @@ def add_html_outcome_view(workflow_id: int) -> Union[str, Response]:
             bucket=form.output_bucket.data,
         )
 
-        outcome_type = manager.outcome_types.get_from_name(name="HTML")
+        outcome_type = manager.outcome_types.get_from_name(name="Text")
         manager.outcomes.add(
             workflow_id=workflow_id,
             outcome_type=outcome_type,
@@ -56,7 +56,7 @@ def add_html_outcome_view(workflow_id: int) -> Union[str, Response]:
     storage_instances = manager.storage_instances.get_all()
 
     return render_template(
-        "top/add_outcome/add_html_outcome.html",
+        "top/add_outcome/add_text_outcome.html",
         form=form,
         workflow_id=workflow_id,
         storage_instances=storage_instances,

--- a/dashboard/blueprints/top/forms/__init__.py
+++ b/dashboard/blueprints/top/forms/__init__.py
@@ -8,7 +8,7 @@ from .excel import (
     CreateExcelTableSourceForm as CreateExcelTableSourceForm,
 )
 from .form_field import CreateFormFieldForm as CreateFormFieldForm
-from .html import CreateHTMLOutcomeForm as CreateHTMLOutcomeForm
+from .text import CreateTextOutcomeForm as CreateTextOutcomeForm
 from .meta import CreateMetaDatabase as CreateMetaDatabase
 from .pdf import CreatePDFOutcomeForm as CreatePDFOutcomeForm
 from .sql import CreateRecordSetSourceForm as CreateRecordSetSourceForm

--- a/dashboard/blueprints/top/forms/text.py
+++ b/dashboard/blueprints/top/forms/text.py
@@ -1,4 +1,4 @@
-"""Define HTML forms."""
+"""Define Text forms."""
 
 from flask_wtf import FlaskForm
 from wtforms import SubmitField
@@ -6,9 +6,9 @@ from wtforms import SubmitField
 from .mixins import DownloadAccessorMixin, FileAccessorMixin, OutputFileAccessorMixin
 
 
-class CreateHTMLOutcomeForm(
+class CreateTextOutcomeForm(
     FlaskForm, FileAccessorMixin, OutputFileAccessorMixin, DownloadAccessorMixin
 ):
-    """Create HTML Outcome."""
+    """Create Text Outcome."""
 
     submit = SubmitField()

--- a/dashboard/templates/components/add_outcome_table.html
+++ b/dashboard/templates/components/add_outcome_table.html
@@ -27,9 +27,9 @@
             <tr>
                 <td class="hover:bg-gray-50">
                     <a class="text-sm font-medium text-gray-900 focus:relative"
-                        href="{{ url_for('top.html.add_html_outcome_view', workflow_id=workflow.Id)}}">
+                        href="{{ url_for('top.text.add_text_outcome_view', workflow_id=workflow.Id)}}">
                         <div class="w-full h-full px-8 py-2">
-                            HTML Template
+                            Text File Template
                         </div>
                     </a>
                 </td>

--- a/dashboard/templates/components/cards/outcomes/text_card.html
+++ b/dashboard/templates/components/cards/outcomes/text_card.html
@@ -10,7 +10,7 @@
 
     <div class="flex flex-col">
         <div class="flex flex-row gap-2 mb-2">
-            <h2 class="text-xl font-bold">HTML File</h2>
+            <h2 class="text-xl font-bold">Text File</h2>
             <a class="rounded inline-block px-4 py-2 text-sm font-semibold text-white bg-red-500 hover:bg-red-400 focus:relative"
                 href="{{ url_for('top.outcome.delete_outcome_view', workflow_id=outcome.WorkflowId, outcome_id=outcome.Id) }}">delete</a>
         </div>

--- a/dashboard/templates/top/add_outcome/add_text_outcome.html
+++ b/dashboard/templates/top/add_outcome/add_text_outcome.html
@@ -1,11 +1,11 @@
 
 {% extends "top/add_outcome_layout.html" %}
 
-{% block title %}Add HTML Template{% endblock title %}
+{% block title %}Add Text File Template{% endblock title %}
 
 {% block content %}
 
-<form method="POST" action="{{url_for('top.html.add_html_outcome_view', workflow_id=workflow_id)}}">
+<form method="POST" action="{{url_for('top.text.add_text_outcome_view', workflow_id=workflow_id)}}">
     {{ form.csrf_token }}
 
     <div class="border rounded bg-gray-50 p-4 flex items-center gap-4 mb-4">
@@ -16,7 +16,7 @@
         <div class="flex-col space-y-4">
             <div>
                 <p>
-                Add a HTML Template, useful for emails or reports.
+                Add any Text File, for example CSV or HTML.
                 </p>
             </div>
 

--- a/docs/outcomes.md
+++ b/docs/outcomes.md
@@ -1,7 +1,7 @@
 {% raw %}
 # Outcomes
 
-Outcomes are the final result of Workflow. It can be a Word Document, a PDF, or an HTML document for example. They are defined by a template which contain text fields that will be populated by AutoDocument, for example `{{name}}`. The data loaded by the sources will have a value attributed to "name", which will be inserted into that field in the document. See [Templating](/tempating.md) for more info.
+Outcomes are the final result of Workflow. It can be a Word Document, a PDF, or an Text document for example. They are defined by a template which contain text fields that will be populated by AutoDocument, for example `{{name}}`. The data loaded by the sources will have a value attributed to "name", which will be inserted into that field in the document. See [Templating](/tempating.md) for more info.
 
 Defining an Outcome involves defining the template, and defining the output location. A "File Storage" selection needs to be set for both. See [File Storages](/file_storages.md) for more info. A File Storage selection can be a location to save the generated files, or simply zipped and downloaded straight from the web app.
 


### PR DESCRIPTION
This involves renaming all html based Outcome services and views.

Note: We want existing databases to work with the new text update, so first we run the latest alembic revision which changes HTML to Text as an OutcomeType. Then, the seeding type tables section of flask-init makes sure Text exists as an OutcomeType. This way existing databases from an older version will change HTML to text, while new databases will just add Text as part of the seed.